### PR TITLE
Fix overflow error on windows, go back to allow python 3.12

### DIFF
--- a/relik/retriever/indexers/document.py
+++ b/relik/retriever/indexers/document.py
@@ -8,7 +8,7 @@ from typing import Any, Dict, List, Union
 from relik.common.log import get_logger
 from relik.common.utils import JsonSerializable
 
-csv.field_size_limit(sys.maxsize)
+csv.field_size_limit(min(sys.maxsize, 2147483646))
 
 logger = get_logger(__name__)
 

--- a/setup.py
+++ b/setup.py
@@ -130,7 +130,7 @@ setuptools.setup(
     ],
     install_requires=install_requirements,
     extras_require=extras,
-    python_requires=">=3.10,<3.12",
+    python_requires=">=3.10",
     find_links=find_links,
     entry_points={
         "console_scripts": ["relik = relik.cli.cli:app"],


### PR DESCRIPTION
Fix overflow error on windows seen with versions of python (3.10, 3.11, 3.12), issue https://github.com/SapienzaNLP/relik/issues/15
relik/retriever/indexers/document.py
csv.field_size_limit(sys.maxsize) changed to
csv.field_size_limit(min(sys.maxsize, 2147483646))
(only able to build from source on linux not windows, did test line in windows with python 3.12 cli interpreter)

Should put back allowing python 3.12 that relik 1.0.7 prevents.
Retesting on ubuntu with fresh python 3.12 install, relik 1.0.6 was fine (and build from source with python 3.12 was fine too)
Issue https://github.com/SapienzaNLP/relik/issues/14 on linux was just messed up python 3.12 env.
setup.py
python_requires=">=3.10,<3.12",
change back to:
    python_requires=">=3.10",