### PR TITLE
security: validate Hydra _target_ before instantiate() to prevent ACE (CWE-913)

### DIFF
--- a/relik/inference/annotator.py
+++ b/relik/inference/annotator.py
@@ -772,6 +772,8 @@ class Relik:
         # logger.info(pformat(OmegaConf.to_container(config)))
 
         # load relik from config
+        from relik.inference.utils import _validate_hydra_target
+        _validate_hydra_target(config)
         relik = hydra.utils.instantiate(
             config, _recursive_=False, retriever=retriever, index=index, reader=reader
         )

--- a/relik/inference/utils.py
+++ b/relik/inference/utils.py
@@ -13,6 +13,27 @@ from relik.retriever.pytorch_modules.model import GoldenRetriever
 
 logger = get_logger(__name__)
 
+_SAFE_HYDRA_PREFIXES = ("relik.",)
+
+
+def _validate_hydra_target(config: DictConfig) -> None:
+    """Reject configs whose _target_ points outside trusted relik modules.
+
+    Without this check, hydra.utils.instantiate() on an attacker-supplied
+    config.yaml (e.g. from a malicious HuggingFace model) would execute any
+    Python callable, giving arbitrary code execution on the loading machine
+    (CWE-913 / CWE-94).
+    """
+    target = OmegaConf.select(config, "_target_", default=None)
+    if target is not None and not any(
+        target.startswith(p) for p in _SAFE_HYDRA_PREFIXES
+    ):
+        raise ValueError(
+            f"Unsafe Hydra _target_ '{target}': only targets within "
+            f"{_SAFE_HYDRA_PREFIXES} are permitted. "
+            "Loading models from untrusted sources may execute arbitrary code."
+        )
+
 
 def _instantiate_retriever(
     retriever: GoldenRetriever | DictConfig | Dict,
@@ -39,8 +60,10 @@ def _instantiate_retriever(
     """
     if not isinstance(retriever, GoldenRetriever):
         # convert to DictConfig
+        retriever_cfg = OmegaConf.create(retriever)
+        _validate_hydra_target(retriever_cfg)
         retriever = hydra.utils.instantiate(
-            OmegaConf.create(retriever),
+            retriever_cfg,
             device=device,
             precision=precision,
             **kwargs,
@@ -219,6 +242,7 @@ def _instantiate_index(
 
         # merge the kwargs
         index = OmegaConf.merge(index, OmegaConf.create(kwargs))
+        _validate_hydra_target(index)
         index: BaseDocumentIndex = hydra.utils.instantiate(index)
     else:
         index = index
@@ -367,6 +391,8 @@ def load_reader(
         # if not isinstance(reader, DictConfig):
         reader = OmegaConf.create(reader)
 
+    if isinstance(reader, DictConfig):
+        _validate_hydra_target(reader)
     reader = (
         hydra.utils.instantiate(
             reader,

--- a/relik/retriever/indexers/base.py
+++ b/relik/retriever/indexers/base.py
@@ -546,6 +546,16 @@ class BaseDocumentIndex:
                 "No index or embeddings found in the directory. Remember to index the documents before using the retriever."
             )
 
+        _safe_prefixes = ("relik.",)
+        target = OmegaConf.select(config, "_target_", default=None)
+        if target is not None and not any(
+            target.startswith(p) for p in _safe_prefixes
+        ):
+            raise ValueError(
+                f"Unsafe Hydra _target_ '{target}': only targets within "
+                f"{_safe_prefixes} are permitted. "
+                "Loading models from untrusted sources may execute arbitrary code."
+            )
         document_index = hydra.utils.instantiate(
             config,
             documents=documents,


### PR DESCRIPTION
## Summary

`hydra.utils.instantiate()` is called in multiple places with config loaded directly from HuggingFace Hub (a `config.yaml` fully controlled by the model author). A malicious model can set `_target_` to any Python callable — e.g. `os.system`, `builtins.exec`, or `torch.hub.load` pointing to an attacker-controlled GitHub repo — achieving **arbitrary code execution** on the machine that loads the model.

Affected call sites (all reachable via `Relik.from_pretrained("attacker/model")`):

| File | Function | Line |
|---|---|---|
| `relik/inference/utils.py` | `_instantiate_index()` | ~222 |
| `relik/inference/utils.py` | `_instantiate_retriever()` | ~42 |
| `relik/inference/utils.py` | `load_reader()` | ~371 |
| `relik/inference/annotator.py` | `Relik.from_pretrained()` | ~775 |
| `relik/retriever/indexers/base.py` | `BaseDocumentIndex.from_pretrained()` | ~549 |

Same vulnerability class as CVE-2025-23304 (NeMo) and CVE-2026-22584 (Uni2TS).

## Fix

Added `_validate_hydra_target(config)` in `relik/inference/utils.py` that rejects any `_target_` not prefixed with `relik.`, and called it before every `hydra.utils.instantiate()` invocation in all affected files.

```python
_SAFE_HYDRA_PREFIXES = ("relik.",)

def _validate_hydra_target(config: DictConfig) -> None:
    target = OmegaConf.select(config, "_target_", default=None)
    if target is not None and not any(
        target.startswith(p) for p in _SAFE_HYDRA_PREFIXES
    ):
        raise ValueError(
            f"Unsafe Hydra _target_ '{target}': only targets within "
            f"{_SAFE_HYDRA_PREFIXES} are permitted."
        )
```

## Test plan

- [ ] `Relik.from_pretrained("legit/model")` with a valid `relik.*` target continues to work
- [ ] Config with `_target_: os.system` raises `ValueError` before `hydra.utils.instantiate` is called
- [ ] Config with `_target_: torch.hub.load` raises `ValueError` (blocks the `torch.hub.load` ACE bypass)
- [ ] All existing tests pass

## Security Impact

**CVSS 3.1**: AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:H = **8.8 HIGH**  
A user who runs `Relik.from_pretrained("attacker/model")` with a malicious model executes attacker code with the privileges of the Python process.